### PR TITLE
use relative path for rpc to work behind reverse proxies

### DIFF
--- a/js/rpc.js
+++ b/js/rpc.js
@@ -3,7 +3,7 @@
   Sammy.TransmissionRPC = function(app) {
 
     var rpc = {
-      url: '/transmission/rpc',
+      url: '../rpc',
       session_id: ''
     };
 


### PR DESCRIPTION
I use kettu/transmission behind a reverse proxy that lets me run multiple transmission backends on a single server. I'd like to be able to access them using kettu as:

`http://mysite.example.com/transmission1`
`http://mysite.example.com/transmission2`
`http://mysite.example.com/transmission3`

So I've set up a reverse proxy that knows how to route to each of the transmission instances, this works fine for the html, css, and js assets, but fails when trying to do the rpc, because the rpc uses an absolute path `/transmission/rpc` for the rpc call and that goes to `http://mysite.example.com/transmission/rpc` no matter which transmission instance is making the request.

If you change the url to be relative `../rpc` then it gets routed to the correct transmission instance.

I've tested it and am using it.